### PR TITLE
Broaden exception handling when reading corrupt data from file

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -84,7 +84,7 @@ public class MainApp extends Application {
                         + " populated with a sample AddressBook.");
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
-        } catch (DataLoadingException e) {
+        } catch (Exception e) {
             logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
                     + " Will be starting with an empty AddressBook.");
             initialData = new AddressBook();


### PR DESCRIPTION
This is necessary because Supplier class can return new types of exceptions that are not previously covered, such as DateTimeException and IllegalArgumentException